### PR TITLE
World currency compatibility

### DIFF
--- a/Source/lang/en.json
+++ b/Source/lang/en.json
@@ -17,6 +17,7 @@
   "MERCHANTNPC.permission-none-help": "None (cannot access sheet)",
   "MERCHANTNPC.permission-all-help": "Change all permissions",
   "MERCHANTNPC.buyText": "{buyer} purchases {quantity} x {itemName} for {chatPrice}.",
+  "MERCHANTNPC.sellText": "{seller} sells {quantity} x {itemName} for {chatPrice}.",
   "MERCHANTNPC.buyMerchantDialog-title": "Buy from merchant price modifier",
   "MERCHANTNPC.sellToMerchantDialog-title": "Sell to merchant price Modifier",
   "MERCHANTNPC.quantityDialog-text": "Enter the quantity for the item.",

--- a/Source/merchant/MerchantSheetNPCHelper.ts
+++ b/Source/merchant/MerchantSheetNPCHelper.ts
@@ -7,6 +7,7 @@ import PermissionPlayer from "./PermissionPlayer";
 import Globals from "../Globals";
 import CurrencyCalculator from "./systems/CurrencyCalculator";
 import Dnd5eCurrencyCalculator from "./systems/Dnd5eCurrencyCalculator";
+import World5eCurrencyCalculator from "./systems/World5eCurrencyCalculator";
 import MerchantSheet from "./MerchantSheet";
 import SfrpgCurrencyCalculator from "./systems/SfrpgCurrencyCalculator";
 import SwadeCurrencyCalculator from "./systems/SwadeCurrencyCalculator";
@@ -25,9 +26,12 @@ class MerchantSheetNPCHelper {
 		if (currencyCalculator === null || currencyCalculator === undefined) {
 			let currencyModuleImport = (<Game>game).system.id.charAt(0).toUpperCase() + (<Game>game).system.id.slice(1) + "CurrencyCalculator";
 			Logger.Log("System currency to get: " + currencyModuleImport);
-			if (currencyModuleImport === 'Dnd5eCurrencyCalculator') {
-				currencyCalculator = new Dnd5eCurrencyCalculator();
-				currencyCalculator.initSettings();
+        if ((<Game>game).modules.get("5e-custom-currency")?.active) {
+				    currencyCalculator = new World5eCurrencyCalculator();
+				    currencyCalculator.initSettings();
+      } else if (currencyModuleImport === 'Dnd5eCurrencyCalculator') {
+          currencyCalculator = new Dnd5eCurrencyCalculator();
+          currencyCalculator.initSettings();
 			} else if (currencyModuleImport === 'SfrpgCurrencyCalculator') {
 				// @ts-ignore
 				currencyCalculator = new SfrpgCurrencyCalculator();
@@ -160,7 +164,6 @@ class MerchantSheetNPCHelper {
 		}
 		li.toggleClass("expanded");
 	}
-
 
 	public async changeQuantity(event: JQuery.ClickEvent, actor: Actor) {
 		event.preventDefault();

--- a/Source/merchant/MerchantSheetNPCHelper.ts
+++ b/Source/merchant/MerchantSheetNPCHelper.ts
@@ -212,12 +212,13 @@ class MerchantSheetNPCHelper {
 		d.render(true);
 	}
 
-
 	public async sellItem(target: Actor, dragSource: any, sourceActor: Actor, quantity: number, totalItemsPrice: number) {
-		let sellerFunds = currencyCalculator.actorCurrency(sourceActor);
-		currencyCalculator.addAmountForActor(sourceActor,sellerFunds,totalItemsPrice)
+		  let sellerFunds = currencyCalculator.actorCurrency(sourceActor);
+      let chatPrice = currencyCalculator.priceInText(totalItemsPrice);
+		  currencyCalculator.addAmountForActor(sourceActor,sellerFunds,totalItemsPrice)
+      // @ts-ignore
+			this.chatMessage(sourceActor, target, (<Game>game).i18n.format('MERCHANTNPC.sellText', {seller: sourceActor.name, quantity: quantity, itemName: dragSource.data.name, chatPrice: chatPrice}), dragSource.data, false);
 	}
-
 
 	private async transaction(seller: Actor, buyer: Actor, itemId: string, quantity: number) {
 		console.log(`Buying item: ${seller}, ${buyer}, ${itemId}, ${quantity}`);

--- a/Source/merchant/MerchantSheetNPCHelper.ts
+++ b/Source/merchant/MerchantSheetNPCHelper.ts
@@ -283,12 +283,11 @@ class MerchantSheetNPCHelper {
 	}
 
 	private chatMessage(speaker: Actor, owner: Actor, message: string, item: Item, service: Boolean) {
-		let image =  (service?'':'<div class= "merchant-item-image" style="background-image: url(${item.img})"></div>');
 		if ((<Game>game).settings.get(Globals.ModuleName, "buyChat")) {
 			message = `
             <div class="chat-card item-card" data-actor-id="${owner.id}" data-item-id="${item.id}">
                 <header class="card-header flexrow">
-            		${image}    
+            		<div class= "merchant-item-image" style="background-image: url(${item.img})"></div>
                     <h3 class="item-name">${item.name}</h3>
                 </header>
 

--- a/Source/merchant/systems/World5eCurrencyCalculator.ts
+++ b/Source/merchant/systems/World5eCurrencyCalculator.ts
@@ -1,0 +1,244 @@
+import CurrencyCalculator from "./CurrencyCalculator";
+// @ts-ignore
+// import Item5e from "../../../../systems/dnd5e/module/item/entity.js";
+import MerchantSheet from "../MerchantSheet";
+import MerchantSheetNPCHelper from "../MerchantSheetNPCHelper";
+import {PropertiesToSource} from "@league-of-foundry-developers/foundry-vtt-types/src/types/helperTypes";
+import {ItemData} from "@league-of-foundry-developers/foundry-vtt-types/src/foundry/common/data/data.mjs";
+import * as Console from "console";
+import Globals from "../../Globals";
+
+export default class World5eCurrencyCalculator extends CurrencyCalculator {
+
+    async onDropItemCreate(itemData: PropertiesToSource<ItemData>, caller: MerchantSheet) {
+        // Create a Consumable spell scroll on the Inventory tab
+        if ( (itemData.type === "spell")) {
+            const scroll = await this.createScroll(itemData);
+            itemData = scroll.data;
+        }
+
+        return caller.callSuperOnDropItemCreate(itemData);
+    }
+
+	async createScrollFromSpell(spell: any) {
+
+		// Get spell data
+		const itemData =  spell.toObject();
+		const {actionType, description, source, activation, duration, target, range, damage, save, level} = itemData.data;
+
+		// Get scroll data
+		// @ts-ignore
+		const scrollUuid = `Compendium.${CONFIG.DND5E.sourcePacks.ITEMS}.${CONFIG.DND5E.spellScrollIds[level]}`;
+		const scrollItem = fromUuid(scrollUuid);
+		if (scrollItem === undefined) {
+			return undefined;
+		}
+		// @ts-ignore
+		const scrollData = scrollItem.data;
+		if (scrollData === undefined) {
+			return undefined;
+		}
+
+		// Split the scroll description into an intro paragraph and the remaining details
+		let scrollDescription = '';
+		if (scrollData !== undefined && scrollData.data !== undefined && scrollData.data.description !== undefined) {
+			scrollDescription = scrollData.data.description.value;
+		}
+		const pdel = '</p>';
+		const scrollIntroEnd = scrollDescription.indexOf(pdel);
+		const scrollIntro = scrollDescription.slice(0, scrollIntroEnd + pdel.length);
+		const scrollDetails = scrollDescription.slice(scrollIntroEnd + pdel.length);
+
+		// Create a composite description from the scroll description and the spell details
+		const desc = `${scrollIntro}<hr/><h3>${itemData.name} (Level ${level})</h3><hr/>${description.value}<hr/><h3>Scroll Details</h3><hr/>${scrollDetails}`;
+
+		// Create the spell scroll data
+		const spellScrollData = foundry.utils.mergeObject(scrollData, {
+			name: `${(<Game>game).i18n.localize("DND5E.SpellScroll")}: ${itemData.name}`,
+			img: itemData.img,
+			data: {
+				"description.value": desc.trim(),
+				source,
+				actionType,
+				activation,
+				duration,
+				target,
+				range,
+				damage,
+				save,
+				level
+			}
+		});
+		// @ts-ignore
+		return new this(spellScrollData);
+	}
+
+	async createScroll(itemData: PropertiesToSource<ItemData>) {
+        return await this.createScrollFromSpell(itemData);
+  }
+
+    getStandard(): any {
+        //@ts-ignore
+        return game.settings.get("5e-custom-currency", "Standard");
+    }
+
+    actorCurrency(actor: Actor) {
+        //@ts-ignore
+        let standard = this.getStandard();
+        // @ts-ignore
+        return actor.data.data.currency[standard];
+    }
+
+    buyerHaveNotEnoughFunds(itemCostInGold:number, buyerFunds: any) {
+        return itemCostInGold > buyerFunds;
+    }
+
+    updateActorWithNewFunds(buyer: Actor, buyerFunds: any) {
+        console.log("Merchant sheet | buyer and funds", buyer,buyerFunds)
+        buyer.update({ "data.currency.cp": buyerFunds });
+    }
+
+    subtractAmountFromActor(buyer: Actor, buyerFunds: any, itemCostInGold: number) {
+        buyerFunds = buyerFunds - itemCostInGold;
+        this.updateActorWithNewFunds(buyer, buyerFunds);
+        console.log(`Merchant Sheet | Funds after purchase: ${buyerFunds}`);
+    }
+
+    addAmountForActor(seller: Actor, sellerFunds: any, price: number) {
+        sellerFunds = (sellerFunds * 1) + (price * 1);
+        this.updateActorWithNewFunds(seller, sellerFunds);
+        console.log(`Merchant Sheet | Funds after sell: ${sellerFunds}`);
+    }
+
+    priceInText(itemCostInGold: number): string {
+        //@ts-ignore
+        let standard = this.getStandard();
+        // @ts-ignore
+        return itemCostInGold + " " + this.abbreviation();
+    }
+
+    public prepareItems(items: any) {
+
+        console.log("Merchant Sheet | Prepare Features");
+        // Actions
+        const features = {
+            weapons: {
+                label: (<Game>game).i18n.localize("MERCHANTNPC.weapons"),
+                items: [],
+                type: "weapon"
+            },
+            equipment: {
+                label: (<Game>game).i18n.localize("MERCHANTNPC.equipment"),
+                items: [],
+                type: "equipment"
+            },
+            consumables: {
+                label: (<Game>game).i18n.localize("MERCHANTNPC.consumables"),
+                items: [],
+                type: "consumable"
+            },
+            tools: {
+                label: (<Game>game).i18n.localize("MERCHANTNPC.tools"),
+                items: [],
+                type: "tool"
+            },
+            containers: {
+                label: (<Game>game).i18n.localize("MERCHANTNPC.containers"),
+                items: [],
+                type: "container"
+            },
+            loot: {
+                label: (<Game>game).i18n.localize("MERCHANTNPC.loot"),
+                items: [],
+                type: "loot"
+            },
+
+        };
+		// @ts-ignore
+        features.weapons.items = items.weapon
+        features.weapons.items.sort(this.sort());
+		// @ts-ignore
+        features.equipment.items = items.equipment
+        features.equipment.items.sort(this.sort());
+
+		// @ts-ignore
+		features.consumables.items = items.consumable
+        features.consumables.items.sort(this.sort());
+		// @ts-ignore
+        features.tools.items = items.tool
+        features.tools.items.sort(this.sort());
+
+		// @ts-ignore
+		features.containers.items = items.backpack
+        features.containers.items.sort(this.sort());
+		// @ts-ignore
+        features.loot.items = items.loot
+        features.loot.items.sort(this.sort());
+        return features;
+    }
+
+	public sort() {
+		return function (a: ItemData, b: ItemData) {
+			return a.name.localeCompare(b.name);
+		};
+	}
+
+	public initSettings() {
+		(<Game>game).settings.register(Globals.ModuleName, "convertCurrency", {
+            name: "Convert currency after purchases?",
+            hint: "If enabled, all currency will be converted to the highest denomination possible after a purchase. If disabled, currency will subtracted simply.",
+            scope: "world",
+            config: true,
+            default: false,
+            type: Boolean
+        });
+      $
+      super.initSettings();
+  }
+
+    gpToStandard(n: number) {
+        //@ts-ignore
+        let standard = this.getStandard();
+        //@ts-ignore
+        return n * CONFIG.DND5E.currencies.gp.conversion[standard];
+    }
+
+    standardToGp(n: number) {
+        // @ts-ignore
+        let standard = this.getStandard();
+        // @ts-ignore
+        return n / CONFIG.DND5E.currencies.gp.conversion[standard];
+    }
+
+    getPriceFromItem(item: Item) {
+        // @ts-ignore
+        return this.gpToStandard(item.data.price);
+    }
+
+    getPriceItemKey() {
+        return "data.price";
+    }
+
+    getPrice(priceValue: number): any {
+        // @ts-ignore
+        return this.standardToGp(priceValue);
+    }
+
+    currency(): string {
+        //@ts-ignore
+        let standard = this.getStandard();
+        // @ts-ignore
+        return CONFIG.DND5E.currencies[standard].label;
+    }
+
+    abbreviation(): string {
+        //@ts-ignore
+        let standard = this.getStandard();
+        // @ts-ignore
+        return " " + CONFIG.DND5E.currencies[standard].abbreviation;
+    }
+
+    getPriceOutputWithModifier(basePrice: any, modifier: number): string {
+        return this.gpToStandard((Math.round((<number>basePrice) * modifier * 100) / 100)).toLocaleString('en') + this.abbreviation();
+    }
+}


### PR DESCRIPTION
This merge request makes three changes.

1. Adds a chat message that triggers when players sell an item. I'm guessing that this is a welcome change.
2. Fixes images not displaying in chat message. This broke when support for services was added. We may want to change it again in the future if you feel strongly about services not having images. That said, why shouldn't services have images? It seems better to allow GMs to add images to the services that their merchant offers.
3. Adds compatibility for World Currencies 5e (https://github.com/cstby/foundryvtt-world-currency-5e).