### PR TITLE
Replace old module name

### DIFF
--- a/Source/merchant/MerchantSheetNPCHelper.ts
+++ b/Source/merchant/MerchantSheetNPCHelper.ts
@@ -26,7 +26,7 @@ class MerchantSheetNPCHelper {
 		if (currencyCalculator === null || currencyCalculator === undefined) {
 			let currencyModuleImport = (<Game>game).system.id.charAt(0).toUpperCase() + (<Game>game).system.id.slice(1) + "CurrencyCalculator";
 			Logger.Log("System currency to get: " + currencyModuleImport);
-        if ((<Game>game).modules.get("5e-custom-currency")?.active) {
+        if ((<Game>game).modules.get("world-currency-5e")?.active) {
 				    currencyCalculator = new World5eCurrencyCalculator();
 				    currencyCalculator.initSettings();
       } else if (currencyModuleImport === 'Dnd5eCurrencyCalculator') {

--- a/Source/merchant/systems/World5eCurrencyCalculator.ts
+++ b/Source/merchant/systems/World5eCurrencyCalculator.ts
@@ -79,7 +79,7 @@ export default class World5eCurrencyCalculator extends CurrencyCalculator {
 
     getStandard(): any {
         //@ts-ignore
-        return game.settings.get("5e-custom-currency", "Standard");
+        return game.settings.get("world-currency-5e", "Standard");
     }
 
     actorCurrency(actor: Actor) {


### PR DESCRIPTION
I apologize about sending another pull request. I was running some tests and preparing to update my module's readme, and I noticed a small bug. This PR fixes the issue.

To respond to your previous question, my module does not yet have an API. There's almost no code overlap between my previous pull request and the world-currency-5e module.