### PR TITLE
Add compatibility for world-currency 2.0

### DIFF
--- a/Source/merchant/systems/World5eCurrencyCalculator.ts
+++ b/Source/merchant/systems/World5eCurrencyCalculator.ts
@@ -187,14 +187,14 @@ export default class World5eCurrencyCalculator extends CurrencyCalculator {
         //@ts-ignore
         let standard = this.getStandard();
         //@ts-ignore
-        return n * CONFIG.DND5E.currencies.gp.conversion[standard];
+        return n * CONFIG.DND5E.currencies[standard].conversion;
     }
 
     standardToGp(n: number) {
         // @ts-ignore
         let standard = this.getStandard();
         // @ts-ignore
-        return n / CONFIG.DND5E.currencies.gp.conversion[standard];
+        return n / CONFIG.DND5E.currencies[standard].conversion;
     }
 
     getPriceFromItem(item: Item) {


### PR DESCRIPTION
I'm updating my module world currency 5e to use a different conversion schema. I'm also attempting to merge this new schema into the DND5E system.

This merge request ensures compatibility with my module.